### PR TITLE
Add idling resource direct support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,9 @@ apply plugin: 'com.jakewharton.hugo'
 buildscript {
     repositories {
         jcenter()
+        maven{
+            url "https://maven.google.com"
+        }
     }
     dependencies {
         classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
@@ -22,6 +25,7 @@ android {
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -31,6 +35,7 @@ android {
     }
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        androidTest.java.srcDirs += "src/androidTest/kotlin"
     }
 }
 
@@ -45,6 +50,16 @@ dependencies {
 
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4-beta2'
     testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
+
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+    androidTestCompile('com.android.support.test.espresso:espresso-contrib:2.2.2') {
+        exclude group: 'com.android.support'
+    }
+    androidTestCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
+}
+
+configurations.all {
+    resolutionStrategy.force 'com.android.support:support-annotations:24.2.1'
 }
 
 repositories {

--- a/app/src/androidTest/kotlin/com/example/asyncawait/AsyncIdlingResource.kt
+++ b/app/src/androidTest/kotlin/com/example/asyncawait/AsyncIdlingResource.kt
@@ -1,0 +1,27 @@
+package com.example.asyncawait
+
+import android.support.test.espresso.IdlingResource
+import co.metalab.asyncawait.onIdleCoroutines
+import co.metalab.asyncawait.onRunningCoroutine
+
+class AsyncIdlingResource : IdlingResource {
+
+    private var areCoroutinesIdle = true
+    private var callback: IdlingResource.ResourceCallback? = null
+
+    override fun getName(): String = "AsyncIdlingResource"
+
+    override fun isIdleNow(): Boolean = areCoroutinesIdle
+
+    override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
+        this.callback = callback
+        onRunningCoroutine = {
+            areCoroutinesIdle = false
+            callback?.onTransitionToIdle()
+        }
+        onIdleCoroutines = {
+            areCoroutinesIdle = true
+            callback?.onTransitionToIdle()
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/com/example/asyncawait/MainActivityTest.kt
+++ b/app/src/androidTest/kotlin/com/example/asyncawait/MainActivityTest.kt
@@ -1,0 +1,62 @@
+package com.example.asyncawait
+
+import android.content.Intent
+import android.os.Bundle
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.Espresso.registerIdlingResources
+import android.support.test.espresso.Espresso.unregisterIdlingResources
+import android.support.test.espresso.IdlingResource
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.intent.rule.IntentsTestRule
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.support.test.runner.AndroidJUnit4
+import co.metalab.asyncawaitsample.MainActivity
+import co.metalab.asyncawaitsample.R
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+
+    @Rule
+    @JvmField
+    val testRule: IntentsTestRule<MainActivity> = IntentsTestRule(MainActivity::class.java, true, false)
+
+    private val asyncIdlingResource: IdlingResource = AsyncIdlingResource()
+
+    @Before
+    fun setUp() {
+        registerIdlingResources(asyncIdlingResource)
+    }
+
+    @After
+    fun tearDown() {
+        unregisterIdlingResources(asyncIdlingResource)
+    }
+
+    @Test
+    fun testAsync() {
+        startActivity()
+
+        clickOnAwaitWithProgressButton()
+
+        onView(withId(R.id.txtResult))
+                .check(matches(withText("Loaded Text")))
+    }
+
+    private fun clickOnAwaitWithProgressButton() {
+        onView(withId(R.id.btnAwaitWithProgress))
+                .perform(click())
+    }
+
+    private fun startActivity(args: Bundle = Bundle()): MainActivity {
+        val intent = Intent()
+        intent.putExtras(args)
+        return testRule.launchActivity(intent)
+    }
+}


### PR DESCRIPTION
This is my proposed solution for issue https://github.com/metalabdesign/AsyncAwait/issues/25. 

* Create two callback methods that are used whenever a coroutine starts execution in a different thread or when all coroutines finish.
* Create an idling resource implementation that register those callbacks and resumes execution only if there are no coroutines being executed.
* Create an espresso test that verifies the new feature works just as expected.

I followed a very similar approach to what Jake Wharton used for OkHttp3 (https://github.com/JakeWharton/okhttp-idling-resource/blob/master/src/main/java/com/jakewharton/espresso/OkHttp3IdlingResource.java). I thought it was better to create two different callbacks to hide as much as possible from the implementation, though.

Personally, I'd recommend to release this feature as a different module so that developers can load the new dependency only for testing builds but being such a small feature I'd understand including it in the very same library.